### PR TITLE
New: added endorctl_scan rule

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,4 @@ jobs:
       
       - name: help
         run: bazel run @rules_endorctl_toolchains//:endorctl -- --help 
-
-      - name: test
-        run: bazel test //...
         

--- a/README.md
+++ b/README.md
@@ -26,6 +26,48 @@ load("@rules_endor//endorctl:repositories.bzl", "rules_endorctl_toolchains")
 rules_endorctl_toolchains()
 ```
 
+## Rules
+
+You have two choices to use `endorctl` through the bazel rule, either by using the CLI directly or by using the endor rules.
+
+```
+bazel run @rules_endorctl_toolchains//:endorctl -- --help
+```
+
+or
+
+```starlark
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_endor//endorctl:defs.bzl", "endorctl_scan")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "java-maven-lib",
+    srcs = glob([
+        "src/main/java/com/example/myproject/App.java",
+    ]),
+    deps = [
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_errorprone_error_prone_annotations",
+        "@maven//:com_google_j2objc_j2objc_annotations",
+        "@maven//:org_checkerframework_checker_qual",
+        "@maven//:org_codehaus_mojo_animal_sniffer_annotations",
+        "@maven//:org_apache_commons_commons_text",
+    ],
+)
+
+endorctl_scan(
+    name = "endorctl-scan",
+    targets = [
+        ":java-maven-lib",
+    ],
+    scan_args = [
+        "--namespace=test_namespace"
+    ],
+)
+```
+
 ## Development
 
 The repository follows the [official recommendation](https://bazel.build/rules/deploying) on deploying bazel rules.

--- a/endorctl/BUILD.bazel
+++ b/endorctl/BUILD.bazel
@@ -9,3 +9,11 @@ bzl_library(
         "//endorctl/internal:toolchain",
     ],
 )
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    deps = [
+        "//endorctl/internal:scan",
+    ],
+)

--- a/endorctl/defs.bzl
+++ b/endorctl/defs.bzl
@@ -1,0 +1,6 @@
+"""
+# rules for using endorctl
+"""
+
+load("//endorctl/internal:scan.bzl", _endorctl_scan_test = "endorctl_scan_test")
+endorctl_scan = _endorctl_scan_test

--- a/endorctl/internal/BUILD.bazel
+++ b/endorctl/internal/BUILD.bazel
@@ -11,3 +11,8 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
+
+bzl_library(
+    name = "scan",
+    srcs = ["scan.bzl"],
+)

--- a/endorctl/internal/scan.bzl
+++ b/endorctl/internal/scan.bzl
@@ -1,0 +1,47 @@
+"""Defines endorctl_scan rule"""
+
+_DOC = """
+`endorctl_scan` is a test rule that run endorctl scan.
+"""
+
+_TOOLCHAIN = str(Label("//endorctl/tools/endorctl:toolchain_type"))
+
+def _endorctl_scan(ctx):
+    cmd = "{} scan --use-bazel".format(ctx.toolchains[_TOOLCHAIN].cli.short_path)
+
+    for target in ctx.attr.targets:
+        cmd = "{} --bazel-include-targets={}".format(cmd, str(target.label))
+
+    for args in ctx.attr.scan_args:
+        cmd = "{} {}".format(cmd, args)
+
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = cmd,
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                files = [ctx.toolchains[_TOOLCHAIN].cli],
+            ),
+        ),
+    ]
+
+endorctl_scan_test = rule(
+    implementation = _endorctl_scan,
+    doc = _DOC,
+    attrs = {
+        "targets": attr.label_list(
+            mandatory = True,
+            doc = "The targets to scan",
+        ),
+        "scan_args": attr.string_list(
+            doc = "Additional args given to endorctl for the scan."
+        ),
+    },
+    
+    toolchains = [_TOOLCHAIN],
+    test = True,
+)

--- a/endorctl/repositories.bzl
+++ b/endorctl/repositories.bzl
@@ -1,5 +1,4 @@
 """Toolchains required to use rules_endorctl."""
 
 load("//endorctl/internal:toolchain.bzl", _rules_endorctl_toolchains = "rules_endorctl_toolchains")
-
 rules_endorctl_toolchains = _rules_endorctl_toolchains

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+load("//endorctl:defs.bzl", "endorctl_scan")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,5 +26,14 @@ java_test(
         ":java-maven-lib",
         "@maven//:junit_junit",
     ]
+)
 
+endorctl_scan(
+    name = "endorctl-scan",
+    targets = [
+        ":java-maven-lib",
+    ],
+    scan_args = [
+        "--namespace=test_namespace"
+    ],
 )


### PR DESCRIPTION
Support for

```
load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_endor//endorctl:defs.bzl", "endorctl_scan")

 package(default_visibility = ["//visibility:public"])

 java_library(
     name = "java-maven-lib",
     srcs = glob([
         "src/main/java/com/example/myproject/App.java",
     ]),
     deps = [
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_errorprone_error_prone_annotations",
         "@maven//:com_google_j2objc_j2objc_annotations",
         "@maven//:org_checkerframework_checker_qual",
         "@maven//:org_codehaus_mojo_animal_sniffer_annotations",
         "@maven//:org_apache_commons_commons_text",
     ],
 )

 endorctl_scan(
     name = "endorctl-scan",
     targets = [
         ":java-maven-lib",
     ],
     scan_args = [
         "--namespace=test_namespace"
     ],
 )
```