### PR TITLE
New: possibility to give a specific version to rules_endorctl_toolchains

### DIFF
--- a/endorctl/internal/toolchain.bzl
+++ b/endorctl/internal/toolchain.bzl
@@ -147,7 +147,7 @@ def _endorctl_download_releases_impl(ctx):
 
     ctx.report_progress("Finding sha of endorctl")
     ctx.download(
-        url = "{}/meta/version/{}".format(repository_url, version),
+        url = "{}/meta/version/v{}".format(repository_url, version),
         output = "sha256s.json",
     )
     sha256s_data = ctx.read("sha256s.json")

--- a/endorctl/internal/toolchain.bzl
+++ b/endorctl/internal/toolchain.bzl
@@ -147,9 +147,7 @@ def _endorctl_download_releases_impl(ctx):
 
     ctx.report_progress("Finding sha of endorctl")
     ctx.download(
-        # TODO: activate this once in prod.
-        #url = "{}/meta/version/{}".format(repository_url, version),
-        url = "{}/meta/version".format(repository_url),
+        url = "{}/meta/version/{}".format(repository_url, version),
         output = "sha256s.json",
     )
     sha256s_data = ctx.read("sha256s.json")


### PR DESCRIPTION
We can do the following:

```
load("//endorctl:repositories.bzl", "rules_endorctl_toolchains")
rules_endorctl_toolchains(version="1.6.34")
```